### PR TITLE
feat: add GitHub Action for automated native riscv64 builds

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -17,14 +17,12 @@ on:
         default: false
 
 env:
-  RISCV64_REMOTE_HOST: ${{ secrets.RISCV64_REMOTE_HOST }}
-  RISCV64_REMOTE_USER: ${{ secrets.RISCV64_REMOTE_USER }}
-  RISCV64_REMOTE_BUILD_DIR: ${{ secrets.RISCV64_REMOTE_BUILD_DIR || 'nodejs-builds' }}
+  BUILD_DIR: nodejs-builds
 
 jobs:
   check-releases:
     name: Check for new Node.js releases
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, RISCV64]
     outputs:
       versions: ${{ steps.check.outputs.versions }}
       has_new: ${{ steps.check.outputs.has_new }}
@@ -88,31 +86,80 @@ jobs:
       - name: Set up build environment
         run: |
           # Ensure required tools are installed
-          command -v rsync >/dev/null 2>&1 || sudo apt-get install -y rsync
-          command -v xz >/dev/null 2>&1 || sudo apt-get install -y xz-utils
+          command -v xz >/dev/null 2>&1 || sudo apt-get update && sudo apt-get install -y xz-utils
+          command -v ccache >/dev/null 2>&1 || sudo apt-get install -y ccache
+          command -v python3 >/dev/null 2>&1 || sudo apt-get install -y python3
 
-          # Create staging directory
-          mkdir -p staging/release/${{ matrix.version }}
+          # Create build directory structure
+          mkdir -p $HOME/${{ env.BUILD_DIR }}/{staging,ccache,logs}
+
+      - name: Download Node.js source
+        run: |
+          VERSION="${{ matrix.version }}"
+          VERSION_NO_V="${VERSION#v}"
+
+          # Download source if not already present
+          if [ ! -f "$HOME/${{ env.BUILD_DIR }}/staging/node-${VERSION}.tar.xz" ]; then
+            echo "Downloading Node.js ${VERSION} source..."
+            curl -LO "https://nodejs.org/dist/${VERSION}/node-${VERSION}.tar.xz"
+            mv "node-${VERSION}.tar.xz" "$HOME/${{ env.BUILD_DIR }}/staging/"
+          else
+            echo "Source already downloaded"
+          fi
 
       - name: Build Node.js ${{ matrix.version }}
         id: build
         run: |
-          echo "Building Node.js ${{ matrix.version }} natively on riscv64..."
+          VERSION="${{ matrix.version }}"
+          VERSION_NO_V="${VERSION#v}"
+          BUILD_DIR="$HOME/${{ env.BUILD_DIR }}"
 
-          # Run the native build script
-          bash bin/test_native_build.sh -v ${{ matrix.version }}
+          echo "Building Node.js ${VERSION} natively on riscv64..."
+          echo "Build directory: ${BUILD_DIR}"
+          echo "CPU count: $(nproc)"
+          echo "Memory: $(free -h | grep Mem | awk '{print $2}')"
+
+          # Extract source
+          cd "${BUILD_DIR}/staging"
+          rm -rf "node-${VERSION}"
+          tar -xf "node-${VERSION}.tar.xz"
+          cd "node-${VERSION}"
+
+          # Set up ccache
+          export CC="ccache gcc"
+          export CXX="ccache g++"
+          export CCACHE_DIR="${BUILD_DIR}/ccache"
+          export CCACHE_MAXSIZE="5G"
+
+          # Show ccache stats before build
+          echo "=== ccache stats before build ==="
+          ccache -s || true
+
+          # Build Node.js
+          echo "Starting Node.js build..."
+          time make -j$(nproc) binary V= \
+            DESTCPU="riscv64" \
+            ARCH="riscv64" \
+            VARIATION="" \
+            DISTTYPE="release" \
+            CONFIG_FLAGS="--openssl-no-asm" \
+            2>&1 | tee "${BUILD_DIR}/logs/build-${VERSION}.log"
+
+          # Show ccache stats after build
+          echo "=== ccache stats after build ==="
+          ccache -s || true
 
           # Check if build succeeded
-          if ls staging/release/${{ matrix.version }}/node-*.tar.?z 1> /dev/null 2>&1; then
-            echo "Build completed successfully"
+          if ls node-*.tar.?z 1> /dev/null 2>&1; then
+            echo "Build completed successfully!"
+            ls -lh node-*.tar.?z
+
+            # Copy binaries to workflow workspace
+            mkdir -p "${GITHUB_WORKSPACE}/staging/release/${VERSION}"
+            cp node-*.tar.?z "${GITHUB_WORKSPACE}/staging/release/${VERSION}/"
+            cp "${BUILD_DIR}/logs/build-${VERSION}.log" "${GITHUB_WORKSPACE}/staging/release/${VERSION}/" || true
+
             echo "success=true" >> $GITHUB_OUTPUT
-
-            # Get tarball names
-            TARBALL_GZ=$(ls staging/release/${{ matrix.version }}/node-*.tar.gz 2>/dev/null || echo "")
-            TARBALL_XZ=$(ls staging/release/${{ matrix.version }}/node-*.tar.xz 2>/dev/null || echo "")
-
-            echo "tarball_gz=${TARBALL_GZ}" >> $GITHUB_OUTPUT
-            echo "tarball_xz=${TARBALL_XZ}" >> $GITHUB_OUTPUT
           else
             echo "Build failed - no output tarballs found"
             echo "success=false" >> $GITHUB_OUTPUT
@@ -122,7 +169,7 @@ jobs:
       - name: Generate checksums
         if: steps.build.outputs.success == 'true'
         run: |
-          cd staging/release/${{ matrix.version }}
+          cd ${GITHUB_WORKSPACE}/staging/release/${{ matrix.version }}
           sha256sum node-*.tar.gz > SHASUMS256.txt 2>/dev/null || true
           sha256sum node-*.tar.xz >> SHASUMS256.txt 2>/dev/null || true
           cat SHASUMS256.txt
@@ -190,9 +237,9 @@ jobs:
           gh release create "${VERSION}" \
             --title "Node.js ${VERSION} for RISC-V 64" \
             --notes-file release_notes.md \
-            staging/release/${VERSION}/node-*.tar.gz \
-            staging/release/${VERSION}/node-*.tar.xz \
-            staging/release/${VERSION}/SHASUMS256.txt
+            ${GITHUB_WORKSPACE}/staging/release/${VERSION}/node-*.tar.gz \
+            ${GITHUB_WORKSPACE}/staging/release/${VERSION}/node-*.tar.xz \
+            ${GITHUB_WORKSPACE}/staging/release/${VERSION}/SHASUMS256.txt
 
           echo "Release ${VERSION} created successfully!"
 
@@ -210,15 +257,21 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-log-${{ matrix.version }}
-          path: staging/release/${{ matrix.version }}/build.log
+          path: ${GITHUB_WORKSPACE}/staging/release/${{ matrix.version }}/build.log
           if-no-files-found: ignore
           retention-days: 30
+
+      - name: Clean up build artifacts
+        if: always()
+        run: |
+          # Keep ccache but clean up build directory to save disk space
+          rm -rf "$HOME/${{ env.BUILD_DIR }}/staging/node-${{ matrix.version }}"
 
   summary:
     name: Build Summary
     needs: [check-releases, build]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, RISCV64]
     steps:
       - name: Generate summary
         run: |


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically builds Node.js binaries natively on riscv64 hardware using a self-hosted runner.

## Features

- **Scheduled Builds**: Runs daily at 02:00 UTC to check for new Node.js releases
- **Manual Builds**: Can be triggered via workflow_dispatch with version selection
- **Automatic Releases**: Creates GitHub releases with binaries as downloadable assets
- **Native Compilation**: Builds directly on riscv64 runner (not cross-compiled)
- **ccache Optimization**: Reuses compiled objects for faster subsequent builds
- **Disk Management**: Auto-cleanup of build artifacts to save space

## Architecture

The workflow runs **directly on the self-hosted riscv64 GitHub runner** (no SSH needed):

1. Runner checks for new Node.js releases from nodejs.org
2. Downloads source tarball
3. Builds locally using native gcc and ccache
4. Creates GitHub releases with both .tar.gz and .tar.xz binaries
5. Generates SHA256 checksums

## Changes

### Workflow File
- `.github/workflows/native-riscv64-build.yml` - Main workflow
- `.github/workflows/README.md` - Comprehensive documentation

### Requirements

- Self-hosted runner on riscv64 machine
- Runner labels: `self-hosted`, `Linux`, `RISCV64`
- Required tools: gcc, g++, make, python3, git, ccache, xz-utils

**No repository secrets required** - builds run locally on the runner!

## Testing Plan

- [ ] Verify runner is online and has correct labels
- [ ] Trigger manual build via workflow_dispatch
- [ ] Verify build completes successfully
- [ ] Verify GitHub release is created with binaries
- [ ] Verify checksums are correct

## Notes

- Works on private networks (only outbound HTTPS needed)
- Builds one version at a time (15+ hour builds are safe)
- Automatic cleanup preserves ccache but removes build artifacts

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>