### PR TITLE
fix: ensure LTS-only filtering for scheduled builds and extend timeout

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -2,7 +2,7 @@ name: Native RISC-V 64 Build
 
 on:
   schedule:
-    # Run daily at 02:00 UTC to check for new Node.js releases
+    # Run daily at 02:00 UTC to check for new Node.js LTS releases
     - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
@@ -45,7 +45,14 @@ jobs:
           else
             # Check for new releases from nodejs.org
             # Column 1: version, Column 10: lts (codename or "-")
-            if [ "${{ inputs.lts_only }}" = "true" ]; then
+            # For scheduled runs, default to LTS only. For manual runs, use input parameter.
+            LTS_ONLY="${{ inputs.lts_only }}"
+            if [ -z "$LTS_ONLY" ]; then
+              # Default to true for scheduled runs (where inputs.lts_only is empty)
+              LTS_ONLY="true"
+            fi
+
+            if [ "$LTS_ONLY" = "true" ]; then
               echo "Checking for LTS versions only..."
               LATEST_RELEASES=$(curl -sL https://nodejs.org/download/release/index.tab | \
                 awk 'NR>1 && $10 != "-" {print $1}' | \
@@ -89,6 +96,7 @@ jobs:
     needs: check-releases
     if: needs.check-releases.outputs.has_new == 'true'
     runs-on: [self-hosted, Linux, RISCV64]
+    timeout-minutes: 1200  # 20 hours - riscv64 builds can take 15+ hours
     strategy:
       matrix:
         version: ${{ fromJson(needs.check-releases.outputs.versions) }}


### PR DESCRIPTION
## Summary

This PR fixes two critical issues with the automated build workflow:

1. **LTS filtering bug**: Scheduled runs were building ALL Node.js versions instead of just LTS versions
2. **Timeout too short**: The default 6-hour timeout was causing long builds to be marked as failed

## Root Cause Analysis

### LTS Filtering Bug

The workflow checked `inputs.lts_only` on line 48, but `inputs` only exists for `workflow_dispatch` events, not `schedule` events. For scheduled runs (cron), this variable was empty, causing the condition to evaluate incorrectly:

```bash
if [ "" = "true" ]; then  # Always false!
```

This caused the workflow to fall through to the `else` block and fetch ALL versions instead of LTS-only versions.

**Evidence**: This morning's run built v25.0.0 and v25.1.0, which are NOT LTS versions:
- v25.0.0: `lts: false`
- v25.1.0: `lts: false`

### Timeout Issue

The default GitHub Actions timeout is 6 hours (360 minutes). However, native riscv64 builds on the Banana Pi F3 typically take 15-18 hours for a full build. This caused builds to be marked as failed even though they were progressing successfully.

**Evidence**: [Run #19186995461](https://github.com/gounthar/unofficial-builds/actions/runs/19186995461) was marked as failed after 6+ hours despite building successfully.

## Changes

1. **Fix LTS filtering** (.github/workflows/native-riscv64-build.yml:49-53):
   - Explicitly check if `inputs.lts_only` is empty
   - Default to `"true"` for scheduled runs
   - Preserve manual override capability for workflow_dispatch

2. **Increase timeout** (.github/workflows/native-riscv64-build.yml:99):
   - Set `timeout-minutes: 1200` (20 hours) for build job
   - Provides comfortable margin for long native builds
   - Prevents false failures on legitimate builds

3. **Update documentation**:
   - Clarify cron comment to specify LTS releases

## Testing

Validated the LTS filtering logic with a test script:
```bash
# Scheduled run (empty input) → defaults to LTS-only ✅
# Manual run with lts_only=true → uses true ✅
# Manual run with lts_only=false → uses false ✅
```

## Impact

- **Scheduled builds**: Will now correctly build only LTS versions (v20.x, v22.x, etc.)
- **Long builds**: Will complete successfully instead of timing out
- **Manual builds**: Retain full control via workflow_dispatch inputs

## Next Actions

After merging:
1. Monitor next scheduled run (02:00 UTC) to verify LTS-only filtering
2. Consider canceling the current failed run if still queued
3. May need to delete v25.0.0 and v25.1.0 releases if they were created