### PR TITLE
fix: use event_name check for LTS filtering instead of input check

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -45,11 +45,11 @@ jobs:
           else
             # Check for new releases from nodejs.org
             # Column 1: version, Column 10: lts (codename or "-")
-            # For scheduled runs, default to LTS only. For manual runs, use input parameter.
-            LTS_ONLY="${{ inputs.lts_only }}"
-            if [ -z "$LTS_ONLY" ]; then
-              # Default to true for scheduled runs (where inputs.lts_only is empty)
+            # For scheduled runs, always use LTS only. For manual runs, use input parameter.
+            if [ "${{ github.event_name }}" = "schedule" ]; then
               LTS_ONLY="true"
+            else
+              LTS_ONLY="${{ inputs.lts_only }}"
             fi
 
             if [ "$LTS_ONLY" = "true" ]; then


### PR DESCRIPTION
## Summary

This PR fixes the LTS filtering logic based on feedback from copilot-pull-request-reviewer in PR #7. The previous implementation incorrectly assumed that inputs.lts_only would be empty for scheduled runs, but GitHub Actions does not work that way.

## Issue with Previous Implementation

The previous code (from PR #7) checked if inputs.lts_only was empty - but GitHub Actions workflow_dispatch inputs are not available for non-dispatch events like schedule. The entire inputs context does not exist for scheduled runs.

References:
- GitHub Community Discussion #29242
- GitHub docs state: This context is only available in a reusable workflow or in a workflow triggered by the workflow_dispatch event.

## Solution

Use github.event_name to explicitly check the trigger type. This approach:
- Is more explicit and clear about intent
- Handles GitHub Actions behavior correctly  
- Still allows manual override via workflow_dispatch

## Testing

The logic now works as follows:
- Scheduled runs (cron at 02:00 UTC): Always use LTS_ONLY=true
- Manual workflow_dispatch runs: Use the lts_only input parameter (defaults to true)
- Manual workflow_dispatch with override: User can set lts_only=false to build all versions

## Credit

Thanks to copilot-pull-request-reviewer for catching this issue and suggesting the event_name approach.

Addresses feedback from #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined Node.js LTS version selection logic in build workflows to consistently use LTS versions for scheduled builds while allowing manual runs to use custom version parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->