### PR TITLE
feat: add Debian and RPM package generation to native RISC-V builds

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -193,8 +193,8 @@ jobs:
         if: steps.build.outputs.success == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ruby ruby-dev build-essential
-          sudo gem install fpm
+          sudo apt-get install -y ruby ruby-dev
+          sudo gem install fpm -v 1.15.1
 
       - name: Build Debian package
         if: steps.build.outputs.success == 'true'
@@ -208,7 +208,7 @@ jobs:
 
           # Extract tarball to prepare for packaging
           tar -xJf "${RELEASE_DIR}/node-${VERSION}-linux-riscv64.tar.xz" \
-            -C package-staging --strip-components=1
+            -C package-staging --strip-components=1 || { echo "Debian package: tar extraction failed"; exit 1; }
 
           # Create .deb package
           fpm -s dir -t deb \
@@ -221,8 +221,8 @@ jobs:
             --license "MIT" \
             --maintainer "Bruno Verachten <https://github.com/gounthar>" \
             --depends "libc6 >= 2.34" \
-            --depends "libssl3" \
-            --depends "zlib1g" \
+            --depends "libssl3 >= 3.0.0" \
+            --depends "zlib1g >= 1:1.2.11" \
             --prefix /usr \
             -C package-staging/ \
             .
@@ -248,7 +248,7 @@ jobs:
 
           # Extract tarball to prepare for packaging
           tar -xJf "${RELEASE_DIR}/node-${VERSION}-linux-riscv64.tar.xz" \
-            -C package-staging --strip-components=1
+            -C package-staging --strip-components=1 || { echo "RPM package: tar extraction failed"; exit 1; }
 
           # Create .rpm package
           fpm -s dir -t rpm \
@@ -261,7 +261,7 @@ jobs:
             --license "MIT" \
             --maintainer "Bruno Verachten <https://github.com/gounthar>" \
             --depends "glibc >= 2.34" \
-            --depends "openssl >= 3.0.0" \
+            --depends "openssl-libs >= 3.0.0" \
             --depends "zlib" \
             --prefix /usr \
             -C package-staging/ \


### PR DESCRIPTION
## Summary

This PR implements automated .deb and .rpm package generation for native RISC-V 64-bit Node.js builds, providing a better user experience compared to manual tarball installation.

## Changes

### Workflow Enhancements

- **Install fpm**: Added installation of the FPM (Effing Package Management) tool to generate packages
- **Debian Package**: Generate `.deb` packages for Debian-based systems (Debian, Ubuntu, etc.)
- **RPM Package**: Generate `.rpm` packages for Fedora-based systems (Fedora, RHEL, openSUSE, etc.)
- **Checksums**: Include package checksums in `SHASUMS256.txt`
- **Release Assets**: Automatically upload packages to GitHub releases

### Package Details

**Naming Convention:**
- Debian: `nodejs_<version>-1_riscv64.deb`
- RPM: `nodejs-<version>-1.riscv64.rpm`

**Dependencies:**
- Debian: `libc6 >= 2.34`, `libssl3`, `zlib1g`
- RPM: `glibc >= 2.34`, `openssl >= 3.0.0`, `zlib`

**Installation Prefix:** `/usr`

**Binaries Included:**
- `/usr/bin/node`
- `/usr/bin/npm`
- `/usr/bin/npx`
- `/usr/bin/corepack`

### Updated Release Notes

Enhanced release notes now include three installation options:

1. **Debian Package (Recommended)** - Simple `dpkg -i` installation
2. **RPM Package** - Simple `rpm -i` installation
3. **Tarball** - Manual extraction (existing method)

Each option includes complete installation commands and verification steps.

## Benefits

### User Experience
- **One-command installation**: `sudo dpkg -i` instead of manual tarball extraction
- **System integration**: Binaries automatically placed in `/usr/bin`
- **Dependency management**: Package managers handle dependency resolution
- **Clean uninstallation**: `apt remove nodejs` or `rpm -e nodejs`

### System Administration
- **Version tracking**: Package managers track installed versions
- **Update compatibility**: Integrates with system update workflows
- **Conflict prevention**: Package managers prevent version conflicts

## Testing Plan

- [ ] Verify .deb package generation on Banana Pi F3 (Debian 13)
- [ ] Test .deb installation: `sudo dpkg -i nodejs_*.deb`
- [ ] Verify RPM package generation
- [ ] Confirm all binaries are accessible in PATH
- [ ] Validate checksums in SHASUMS256.txt
- [ ] Test package uninstallation
- [ ] Verify GitHub release includes all artifacts

## References

- Closes #5
- Inspired by [docker-for-riscv64](https://github.com/gounthar/docker-for-riscv64/) packaging workflows
- Uses [fpm](https://github.com/jordansissel/fpm) for cross-format package generation

## Next Steps (Future Work)

After this PR is merged and validated:
1. Consider APT/DNF repository hosting (GitHub Pages or Cloudflare Pages)
2. Extend packaging to other architectures in unofficial-builds
3. Investigate `update-alternatives` integration for managing multiple Node.js versions

## Release Artifacts Example

After this PR, each release will include:

```
v24.11.0/
├── node-24.11.0-linux-riscv64.tar.gz
├── node-24.11.0-linux-riscv64.tar.xz
├── nodejs_24.11.0-1_riscv64.deb          ⬅️ NEW
├── nodejs-24.11.0-1.riscv64.rpm          ⬅️ NEW
└── SHASUMS256.txt (includes package checksums)
```

## Installation Example

```bash
# Debian/Ubuntu systems
curl -LO https://github.com/gounthar/unofficial-builds/releases/download/v24.11.0/nodejs_24.11.0-1_riscv64.deb
sudo dpkg -i nodejs_24.11.0-1_riscv64.deb
node --version

# Fedora/RHEL systems
curl -LO https://github.com/gounthar/unofficial-builds/releases/download/v24.11.0/nodejs-24.11.0-1.riscv64.rpm
sudo rpm -i nodejs-24.11.0-1.riscv64.rpm
node --version
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RISCV64 native builds now available as Debian (.deb) and RPM (.rpm) packages, providing alternative installation options to manual tarball deployment.

* **Chores**
  * Release workflow enhanced with automated package generation, comprehensive checksum verification across all artifacts, and expanded installation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->