### PR TITLE
fix: install rpm package for rpmbuild command in packaging step

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -218,7 +218,7 @@ jobs:
         if: steps.build.outputs.success == 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ruby ruby-dev
+          sudo apt-get install -y ruby ruby-dev rpm
           sudo gem install fpm -v 1.15.1
 
       - name: Build Debian package


### PR DESCRIPTION
## Summary

Fix RPM package creation failure by installing the `rpm` package which provides the `rpmbuild` command required by fpm.

## Problem

The v24.11.1 build failed during RPM package creation (workflow run 19319301901):
- ✅ Node.js build succeeded
- ✅ Debian package (.deb) created successfully  
- ❌ RPM package (.rpm) failed with: `rpmbuild failed (exit code 1)`

**Root cause**: fpm requires `rpmbuild` to create RPM packages, but the workflow only installed `ruby`, `ruby-dev`, and `fpm`. The `rpmbuild` command is provided by the `rpm` package on Debian.

## Changes

- Added `rpm` to the apt-get install command in the "Install packaging tools" step (line 221)
- No other changes needed - fpm will now be able to find and use rpmbuild

## Verification

The `rpm` package is available for riscv64 in Debian 13 (Trixie):
- Package: rpm version 4.20.1+dfsg-2
- Architectures: amd64 arm64 armel armhf i386 ppc64el **riscv64** s390x
- Provides: /usr/bin/rpmbuild

## Testing Plan

1. Merge this PR
2. Trigger manual workflow build for v24.11.1
3. Verify RPM package is created successfully
4. Verify all 4 artifacts are present in release:
   - node-v24.11.1-linux-riscv64.tar.gz
   - node-v24.11.1-linux-riscv64.tar.xz
   - nodejs_24.11.1-1_riscv64.deb ✅
   - nodejs-24.11.1-1.riscv64.rpm ✅ (should work now)

## Impact

- Fixes ongoing build failures for v24.11.1 and all future Node.js versions
- Allows users to install Node.js using RPM packages on Fedora/RHEL-based riscv64 systems
- Completes the packaging feature added in PR #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling dependencies for the RISC-V64 build pipeline to include additional packaging tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->