### PR TITLE
fix: YAML syntax errors in workflow commit messages

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -167,14 +167,13 @@ jobs:
               fi
 
               # Commit
-              git commit -m "$(cat <<'EOF'
+              git commit -F - <<EOF || {
 feat: add Node.js ${VERSION} package to APT repository
 
 - Added nodejs_${VERSION#v}-1_riscv64.deb
 - Updated repository metadata
 - Updated GPG signatures
 EOF
-)" || {
                 echo "Commit failed, will retry..."
                 sleep $((5 + RANDOM % 6))
                 attempt=$((attempt + 1))

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -213,14 +213,13 @@ jobs:
               fi
 
               # Commit
-              git commit -m "$(cat <<'EOF'
+              git commit -F - <<EOF || {
 feat: add Node.js ${VERSION} package to RPM repository
 
 - Added nodejs-${VERSION#v}-1.riscv64.rpm
 - Updated repository metadata with createrepo_c
 - Signed repomd.xml with GPG
 EOF
-)" || {
                 echo "Commit failed, will retry..."
                 sleep $((5 + RANDOM % 6))
                 attempt=$((attempt + 1))


### PR DESCRIPTION
## Problem

After merging PR #19, both repository update workflows are broken with YAML syntax errors:
- `.github/workflows/update-apt-repo.yml#L172`
- `.github/workflows/update-rpm-repo.yml#L218`

GitHub's YAML parser fails with "You have an error in your yaml syntax" because the heredoc-in-command-substitution approach causes the parser to interpret the commit message content as YAML syntax.

## Root Cause

The following pattern triggers YAML parsing errors:

```yaml
git commit -m "$(cat <<'EOF'
feat: add Node.js ${VERSION} package

- Added package
- Updated metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configurations for enhanced process consistency in automated commit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->