### PR TITLE
fix: correct repository URLs and RPM filename pattern

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -198,16 +198,16 @@ jobs:
           echo "# APT Repository Update Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Repository**: https://gounthar.github.io/nodejs-unofficial-builds" >> $GITHUB_STEP_SUMMARY
+          echo "**Repository**: https://gounthar.github.io/unofficial-builds" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Installation Instructions" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "# Add GPG key" >> $GITHUB_STEP_SUMMARY
-          echo "curl -fsSL https://gounthar.github.io/nodejs-unofficial-builds/KEY.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/nodejs-unofficial.gpg" >> $GITHUB_STEP_SUMMARY
+          echo "curl -fsSL https://gounthar.github.io/unofficial-builds/KEY.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/nodejs-unofficial.gpg" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "# Add repository" >> $GITHUB_STEP_SUMMARY
-          echo 'echo "deb [arch=riscv64 signed-by=/etc/apt/keyrings/nodejs-unofficial.gpg] https://gounthar.github.io/nodejs-unofficial-builds trixie main" | sudo tee /etc/apt/sources.list.d/nodejs-unofficial.list' >> $GITHUB_STEP_SUMMARY
+          echo 'echo "deb [arch=riscv64 signed-by=/etc/apt/keyrings/nodejs-unofficial.gpg] https://gounthar.github.io/unofficial-builds trixie main" | sudo tee /etc/apt/sources.list.d/nodejs-unofficial.list' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "# Install Node.js" >> $GITHUB_STEP_SUMMARY
           echo "sudo apt update" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -76,7 +76,7 @@ jobs:
           # Download the .rpm file from GitHub release
           gh release download "${VERSION}" \
             --repo ${{ github.repository }} \
-            --pattern "nodejs-${VERSION_NO_V}-1.riscv64.rpm" \
+            --pattern "nodejs-${VERSION_NO_V}-*.riscv64.rpm" \
             --dir /tmp/packages || {
               echo "Failed to download .rpm package for ${VERSION}"
               exit 1
@@ -94,7 +94,7 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           VERSION_NO_V="${VERSION#v}"
 
-          RPM_FILE="/tmp/packages/nodejs-${VERSION_NO_V}-1.riscv64.rpm"
+          RPM_FILE=$(ls /tmp/packages/nodejs-${VERSION_NO_V}-*.riscv64.rpm 2>/dev/null | head -1)
 
           if [ ! -f "$RPM_FILE" ]; then
             echo "Error: RPM package not found at $RPM_FILE"
@@ -244,13 +244,13 @@ jobs:
           echo "# RPM Repository Update Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Repository**: https://gounthar.github.io/nodejs-unofficial-builds" >> $GITHUB_STEP_SUMMARY
+          echo "**Repository**: https://gounthar.github.io/unofficial-builds" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "## Installation Instructions" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
           echo "# Download and install repository configuration" >> $GITHUB_STEP_SUMMARY
-          echo "sudo curl -o /etc/yum.repos.d/nodejs-unofficial.repo https://gounthar.github.io/nodejs-unofficial-builds/nodejs-unofficial.repo" >> $GITHUB_STEP_SUMMARY
+          echo "sudo curl -o /etc/yum.repos.d/nodejs-unofficial.repo https://gounthar.github.io/unofficial-builds/nodejs-unofficial.repo" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "# Install Node.js" >> $GITHUB_STEP_SUMMARY
           echo "sudo dnf install nodejs" >> $GITHUB_STEP_SUMMARY
@@ -263,10 +263,10 @@ jobs:
           echo "sudo tee /etc/yum.repos.d/nodejs-unofficial.repo <<EOF" >> $GITHUB_STEP_SUMMARY
           echo "[nodejs-unofficial-riscv64]" >> $GITHUB_STEP_SUMMARY
           echo "name=Node.js Unofficial Builds - RISC-V 64" >> $GITHUB_STEP_SUMMARY
-          echo "baseurl=https://gounthar.github.io/nodejs-unofficial-builds/rpm/fedora/riscv64" >> $GITHUB_STEP_SUMMARY
+          echo "baseurl=https://gounthar.github.io/unofficial-builds/rpm/fedora/riscv64" >> $GITHUB_STEP_SUMMARY
           echo "enabled=1" >> $GITHUB_STEP_SUMMARY
           echo "gpgcheck=1" >> $GITHUB_STEP_SUMMARY
-          echo "gpgkey=https://gounthar.github.io/nodejs-unofficial-builds/KEY.gpg" >> $GITHUB_STEP_SUMMARY
+          echo "gpgkey=https://gounthar.github.io/unofficial-builds/KEY.gpg" >> $GITHUB_STEP_SUMMARY
           echo "repo_gpgcheck=1" >> $GITHUB_STEP_SUMMARY
           echo "EOF" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

This PR fixes two critical issues preventing users from accessing the APT/RPM repositories and preventing the RPM workflow from running successfully:

**1. Incorrect Repository URLs**
- The workflow summaries referenced  but the actual GitHub Pages site is at 
- Updated all URLs in both APT and RPM workflow summaries
- Users can now correctly install packages using the provided instructions

**2. RPM Filename Pattern Mismatch**
- The RPM workflow expected `nodejs-24.11.1-1.riscv64.rpm`
- Actual files include Fedora version: `nodejs-24.11.1-1.fc41.riscv64.rpm`
- Changed download pattern to use wildcard: `nodejs-*-*.riscv64.rpm`
- Modified file detection to dynamically find the downloaded RPM

## Changes

### APT Workflow (.github/workflows/update-apt-repo.yml)
- Line 201: `nodejs-unofficial-builds` → `unofficial-builds`
- Line 207: `nodejs-unofficial-builds` → `unofficial-builds`
- Line 210: `nodejs-unofficial-builds` → `unofficial-builds`

### RPM Workflow (.github/workflows/update-rpm-repo.yml)
- Line 79: Pattern `nodejs-${VERSION_NO_V}-1.riscv64.rpm` → `nodejs-${VERSION_NO_V}-*.riscv64.rpm`
- Line 97: Hardcoded path → Dynamic `ls` to find actual filename
- Lines 247, 253, 266, 269: `nodejs-unofficial-builds` → `unofficial-builds`

## Testing

The APT repository is already accessible and tested:
- ✅ https://gounthar.github.io/unofficial-builds/KEY.gpg
- ✅ https://gounthar.github.io/unofficial-builds/dists/trixie/Release

After merge, the RPM workflow should be re-triggered for v24.11.1 to verify the filename pattern fix.

## Related Issues

- Fixes workflow failure: https://github.com/gounthar/unofficial-builds/actions/runs/19379529389
- Addresses user's 404 errors when trying to install from repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package repository references to new host location
  * Enhanced automated build workflows for improved package resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->