### PR TITLE
fix: resolve git pull rebase conflict in APT workflow

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -149,16 +149,16 @@ jobs:
             while [ $attempt -le $max_attempts ]; do
               echo "Attempt $attempt of $max_attempts"
 
-              # Pull latest changes
-              git pull --rebase origin ${{ env.REPO_BRANCH }} || {
+              # Stage changes from reprepro first
+              git add -A
+
+              # Pull latest changes with autostash
+              git pull --rebase --autostash origin ${{ env.REPO_BRANCH }} || {
                 echo "Pull failed, will retry..."
                 sleep $((5 + RANDOM % 6))
                 attempt=$((attempt + 1))
                 continue
               }
-
-              # Stage all changes
-              git add -A
 
               # Check if there are changes to commit
               if git diff --staged --quiet; then

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -195,16 +195,16 @@ jobs:
             while [ $attempt -le $max_attempts ]; do
               echo "Attempt $attempt of $max_attempts"
 
-              # Pull latest changes
-              git pull --rebase origin ${{ env.REPO_BRANCH }} || {
+              # Stage changes from createrepo_c first
+              git add -A
+
+              # Pull latest changes with autostash
+              git pull --rebase --autostash origin ${{ env.REPO_BRANCH }} || {
                 echo "Pull failed, will retry..."
                 sleep $((5 + RANDOM % 6))
                 attempt=$((attempt + 1))
                 continue
               }
-
-              # Stage all changes
-              git add -A
 
               # Check if there are changes to commit
               if git diff --staged --quiet; then


### PR DESCRIPTION
## Summary
Fixes both APT and RPM workflow failures where `git pull --rebase` fails with "cannot pull with rebase: You have unstaged changes".

## Problem
Both workflows were failing because:
1. `reprepro includedeb`/`createrepo_c` create changes in the repository
2. Workflow tried to `git pull --rebase` without staging these changes first
3. Git refuses to pull with rebase when unstaged changes exist

**Failed run**: https://github.com/gounthar/unofficial-builds/actions/runs/19444880455

Error:
```
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
```

## Solution
- Stage changes with `git add -A` **before** attempting pull
- Use `--autostash` flag which automatically stashes/unstashes during rebase
- This ensures repository tool changes are properly managed during the rebase

## Changes
- `.github/workflows/update-apt-repo.yml`: Moved `git add -A` before pull, added `--autostash` flag
- `.github/workflows/update-rpm-repo.yml`: Same fix applied for consistency

## Test Plan
After merge, retrigger the APT workflow for v24.11.1:
```bash
gh workflow run update-apt-repo.yml --ref main -f version=v24.11.1
```

This should successfully add `nodejs-unofficial_24.11.1-1_riscv64.deb` to the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced git operation handling in automated repository update workflows to improve reliability when managing concurrent changes and rebases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->