### PR TITLE
fix: clean up main-branch directory before committing to repo branches

### DIFF
--- a/.github/workflows/update-apt-repo.yml
+++ b/.github/workflows/update-apt-repo.yml
@@ -132,6 +132,11 @@ jobs:
           # Ensure the public key is available at the repository root
           cp main-branch/KEY.gpg KEY.gpg
 
+      - name: Clean up main-branch checkout
+        run: |
+          # Remove main-branch directory to prevent it from being committed to apt-repo
+          rm -rf main-branch
+
       - name: Commit and push changes with retry logic
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-rpm-repo.yml
+++ b/.github/workflows/update-rpm-repo.yml
@@ -178,6 +178,11 @@ jobs:
           # Copy the .repo file for easy user configuration
           cp main-branch/repo-config/nodejs-unofficial.repo nodejs-unofficial.repo
 
+      - name: Clean up main-branch checkout
+        run: |
+          # Remove main-branch directory to prevent it from being committed to rpm-repo
+          rm -rf main-branch
+
       - name: Commit and push changes with retry logic
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes pages-build-deployment workflow failure caused by main-branch directory being committed to apt-repo/rpm-repo branches.

## Problem
Both APT and RPM workflows check out the main branch to a `main-branch` directory to access config files. The `git add -A` command was including this directory in commits to apt-repo/rpm-repo branches.

This caused the pages-build-deployment workflow to fail with:
```
fatal: No url found for submodule path 'main-branch' in .gitmodules
```

**Failed run**: https://github.com/gounthar/unofficial-builds/actions/runs/19446010340

## Solution
Add a cleanup step to remove the `main-branch` directory after copying needed files but before committing.

## Changes
- `.github/workflows/update-apt-repo.yml`: Added "Clean up main-branch checkout" step
- `.github/workflows/update-rpm-repo.yml`: Added same cleanup step

## Test Plan
After merge:
1. Remove main-branch directory from apt-repo branch manually
2. Retrigger APT workflow for v24.11.1
3. Verify Pages deployment succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated package repository maintenance by removing temporary build artifacts from APT and RPM repositories during release workflows, ensuring cleaner package distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->