### PR TITLE
fix: improve repo update trigger with permissions and error reporting

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -536,6 +536,8 @@ jobs:
 
           if [ "$FAILURES" -eq 0 ]; then
             echo "Both repository update workflows triggered successfully"
+          elif [ "$FAILURES" -eq 1 ]; then
+            echo "::warning::One of the two repository update dispatches failed for ${VERSION}"
           elif [ "$FAILURES" -eq 2 ]; then
             echo "::error::Both repository update dispatches failed for ${VERSION}"
           fi


### PR DESCRIPTION
## Summary

- Add `actions: write` permission to the `build` job so `gh workflow run` dispatch calls work on repos with restricted `GITHUB_TOKEN` defaults
- Replace misleading blanket "Repository update workflows triggered" message with per-dispatch result tracking
- Emit `::warning::` annotations for individual dispatch failures and `::error::` if both fail

Fixes review feedback from #29.

## Changes

**`native-riscv64-build.yml`**:
- Added `permissions: contents: write, actions: write` to the `build` job
- Refactored trigger step to track success/failure of each `gh workflow run` independently
- Uses GitHub Actions annotations (`::warning::`, `::error::`) for visibility in the Actions UI

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Next scheduled build should show individual dispatch results in logs
- [ ] If a dispatch fails, it should appear as a warning annotation in the Actions summary