### PR TITLE
feat: auto-update Docker Hub description on image push

### DIFF
--- a/.github/workflows/update-docker-images.yml
+++ b/.github/workflows/update-docker-images.yml
@@ -142,3 +142,12 @@ jobs:
           echo "  gounthar/node-riscv64:${VERSION}-trixie-slim"
           echo "  gounthar/node-riscv64:latest"
           echo "  gounthar/node-riscv64:slim"
+
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: gounthar/node-riscv64
+          readme-filepath: docker/DOCKERHUB_README.md
+          short-description: "Unofficial Node.js Docker images for RISC-V 64-bit (riscv64) on Debian Trixie"

--- a/docker/DOCKERHUB_README.md
+++ b/docker/DOCKERHUB_README.md
@@ -1,0 +1,63 @@
+# Node.js for RISC-V 64-bit
+
+Unofficial Node.js Docker images for **RISC-V 64-bit** (`linux/riscv64`) based on Debian Trixie.
+
+These images fill the gap left by the [official Node.js images](https://hub.docker.com/_/node), which don't yet include `linux/riscv64` platform support.
+
+## Quick Start
+
+```bash
+docker run --platform linux/riscv64 gounthar/node-riscv64:latest node -e "console.log(process.arch)"
+# riscv64
+```
+
+## Tags
+
+| Tag | Base Image | Description |
+|-----|-----------|-------------|
+| `<version>-trixie` | `buildpack-deps:trixie` | Full variant with build tools (gcc, g++, make) |
+| `<version>-trixie-slim` | `debian:trixie-slim` | Minimal variant, smaller image size |
+| `latest` | `buildpack-deps:trixie` | Latest release, full variant |
+| `slim` | `debian:trixie-slim` | Latest release, slim variant |
+
+## Available Versions
+
+- **Node.js 24.x** (Current)
+- **Node.js 22.x** (LTS)
+
+Check the [Tags](https://hub.docker.com/r/gounthar/node-riscv64/tags) page for all available versions.
+
+## Usage
+
+### As a base image
+
+```dockerfile
+FROM gounthar/node-riscv64:latest
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+CMD ["node", "server.js"]
+```
+
+### Interactive shell
+
+```bash
+docker run -it --platform linux/riscv64 gounthar/node-riscv64:latest
+```
+
+## Why?
+
+RISC-V is an open-source instruction set architecture gaining traction in embedded systems, SBCs, and servers. These images let you develop and test Node.js applications for riscv64 today, using QEMU emulation on any host or natively on RISC-V hardware.
+
+## Included Software
+
+- **Node.js** with npm
+- **Yarn** 1.22.x (Classic)
+- Full variant includes: gcc, g++, make, python3, and other build essentials
+
+## Source
+
+- **GitHub**: [gounthar/unofficial-builds](https://github.com/gounthar/unofficial-builds)
+- **Dockerfiles**: [docker/](https://github.com/gounthar/unofficial-builds/tree/main/docker)
+- **Binaries**: Built natively on RISC-V hardware (Banana Pi F3)

--- a/docker/DOCKERHUB_README.md
+++ b/docker/DOCKERHUB_README.md
@@ -43,7 +43,7 @@ CMD ["node", "server.js"]
 ### Interactive shell
 
 ```bash
-docker run -it --platform linux/riscv64 gounthar/node-riscv64:latest
+docker run -it --platform linux/riscv64 gounthar/node-riscv64:latest bash
 ```
 
 ## Why?


### PR DESCRIPTION
## Summary

- Add `docker/DOCKERHUB_README.md` as the single source of truth for the Docker Hub repository overview
- Add `peter-evans/dockerhub-description@v4` step to the `update-docker-images` workflow to sync the README to Docker Hub after each image push
- Description already pushed to Docker Hub via API for immediate effect

## Test plan

- [ ] Verify `docker/DOCKERHUB_README.md` renders correctly on GitHub
- [ ] Trigger `update-docker-images` workflow and confirm Docker Hub description updates
- [ ] Verify the short description appears on Docker Hub search results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker image deployment pipeline with automated Docker Hub repository description synchronization.

* **Documentation**
  * Published comprehensive documentation for Node.js on RISC-V 64-bit architecture, featuring quick start guides, available version tags, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->