### PR TITLE
fix: run configure before parallel make to prevent .deps race condition

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -186,6 +186,14 @@ jobs:
           echo "=== ccache stats before build ==="
           ccache -s || true
 
+          # Run configure before parallel make so GYP sets up the full Makefile
+          # and .deps directory tree before compilation starts. Without this,
+          # make -j$(nproc) races to write .d.raw dependency files into
+          # directories that don't exist yet (v8_initializers target failure).
+          echo "Configuring Node.js..."
+          ./configure --openssl-no-asm \
+            2>&1 | tee -a "${BUILD_DIR}/logs/build-${VERSION}.log"
+
           # Build Node.js
           echo "Starting Node.js build..."
           time make -j$(nproc) binary V= \
@@ -193,8 +201,7 @@ jobs:
             ARCH="riscv64" \
             VARIATION="" \
             DISTTYPE="release" \
-            CONFIG_FLAGS="--openssl-no-asm" \
-            2>&1 | tee "${BUILD_DIR}/logs/build-${VERSION}.log"
+            2>&1 | tee -a "${BUILD_DIR}/logs/build-${VERSION}.log"
 
           # Show ccache stats after build
           echo "=== ccache stats after build ==="


### PR DESCRIPTION
## Problem

Run [#24817389218](https://github.com/gounthar/unofficial-builds/actions/runs/24817389218) failed after ~10 hours building Node.js v24.14.1 with:

```
fatal error: opening dependency file
  .../out/Release/.deps//home/.../v8_initializers/deps/v8/src/builtins/builtins-async-gen.o.d.raw:
  No such file or directory
compilation terminated.
make[2]: *** [...builtins-async-gen.o] Error 1
```

The root cause: `make -j$(nproc) binary CONFIG_FLAGS=...` runs `configure` embedded inside make. GYP hasn't fully set up the `.deps` directory tree before the parallel compilation jobs start. The `v8_initializers` target spawns many concurrent jobs that race to write `.d.raw` dependency files into directories that don't exist yet.

## Fix

Run `./configure --openssl-no-asm` as an explicit step before the parallel `make`. This ensures GYP creates the full Makefile and `.deps` structure before any compilation job starts. `CONFIG_FLAGS` is then dropped from `make` (redundant once configure ran separately).

## Build time impact

None — configure takes a few seconds. The 10-hour build time is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced RISC-V64 native build process with improved configuration handling and consolidated build logging for better build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->