### PR TITLE
fix: restore CONFIG_FLAGS=--openssl-no-asm on make binary line

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -195,12 +195,17 @@ jobs:
             2>&1 | tee -a "${BUILD_DIR}/logs/build-${VERSION}.log"
 
           # Build Node.js
+          # CONFIG_FLAGS must be passed here too: the `binary` Makefile target
+          # re-runs ./configure internally and uses $(CONFIG_FLAGS) for that
+          # inner invocation. Without it, OpenSSL re-enables x86 asm and gcc
+          # fails on riscv64 with: unrecognized command-line option '-m64'.
           echo "Starting Node.js build..."
           time make -j$(nproc) binary V= \
             DESTCPU="riscv64" \
             ARCH="riscv64" \
             VARIATION="" \
             DISTTYPE="release" \
+            CONFIG_FLAGS="--openssl-no-asm" \
             2>&1 | tee -a "${BUILD_DIR}/logs/build-${VERSION}.log"
 
           # Show ccache stats after build


### PR DESCRIPTION
## Summary

Run [#195](https://github.com/gounthar/unofficial-builds/actions/runs/24912241960) of `Native RISC-V 64 Build` failed at the OpenSSL compile stage with:

```
gcc: error: unrecognized command-line option '-m64'
make[2]: *** [deps/openssl/openssl.target.mk:1327: .../openssl/ssl/bio_ssl.o] Error 1
```

## Root cause

PR #37 added an explicit `./configure --openssl-no-asm` step before `make binary` (to defeat the GYP `.deps` race) and **dropped `CONFIG_FLAGS=--openssl-no-asm`** from the `make binary` invocation as "now redundant". It is not redundant.

The Node.js `binary` Makefile target re-runs `./configure` internally and uses `$(CONFIG_FLAGS)` to extend that inner configure. The build log of run #195 shows it clearly:

1. Explicit pre-configure (line ~21:16:37): `./configure --openssl-no-asm` ✅
2. Inner re-configure invoked by `make binary` (line ~21:16:53):
   ```
   ./configure --prefix=/ --dest-cpu=riscv64 --tag= --release-urlbase= --download=all --with-intl=full-icu
   ```
   No `--openssl-no-asm`. The build files are regenerated with OpenSSL asm re-enabled, and gcc rejects `-m64` on riscv64.

## Fix

Keep both:
- The pre-configure step (avoids the `.deps` race that PR #37 fixed).
- `CONFIG_FLAGS=--openssl-no-asm` on the `make binary` line (so the inner re-configure also disables OpenSSL asm).

## Test plan

- [ ] Re-run `Native RISC-V 64 Build` workflow against this branch and confirm OpenSSL compiles past `bio_ssl.o` / `d1_lib.o` without `-m64` errors
- [ ] Verify build proceeds beyond ~46s (full build is ~95 min native; failure currently happens at ~46s of make)
- [ ] Confirm produced `node-*.tar.?z` artifact is generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved RISC-V64 build configuration for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->