### PR TITLE
ci: run Build Summary on github-hosted runner

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -582,7 +582,12 @@ jobs:
     name: Build Summary
     needs: [check-releases, build]
     if: always()
-    runs-on: [self-hosted, Linux, RISCV64]
+    # Reporting only: writes markdown to $GITHUB_STEP_SUMMARY from context
+    # variables, no RISC-V work. Running it on the self-hosted F3 runner makes
+    # the whole run fail when a runner handoff misses after check-releases
+    # finishes ("job was not acquired by Runner of type self-hosted"). Use a
+    # GitHub-hosted runner so the summary never gates on F3 availability.
+    runs-on: ubuntu-latest
     steps:
       - name: Generate summary
         run: |


### PR DESCRIPTION
The scheduled `Native RISC-V 64 Build` run [#219](https://github.com/gounthar/unofficial-builds/actions/runs/25982768851) failed even though nothing was actually broken.

## What happened

| Job | Runner | Result |
|-----|--------|--------|
| Check for new Node.js releases | `bananapi-f3-nodejs-svc` | success |
| Build Node.js (matrix) | — | skipped (no new LTS to build) |
| Build Summary | none assigned | cancelled after 23m |

After `check-releases` finished, the `summary` job sat in the queue and was never picked up: *"The job was not acquired by Runner of type self-hosted even after multiple attempts"*. That cancelled the job and turned the whole run red, despite the release check succeeding and there being nothing new to build.

No other unofficial-builds run was competing for the runners in that window, so this was a runner-handoff miss after the first job completed, not an overloaded board.

## Fix

The `summary` job only echoes markdown into `$GITHUB_STEP_SUMMARY` from context variables. It does no RISC-V work, so pinning it to the self-hosted F3 runner gives the run an extra failure mode for zero benefit. Moving it to `ubuntu-latest` makes the reporting step run instantly and reliably, independent of F3 runner availability.

No change to `check-releases` or `build`, which still run on the self-hosted runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow reliability to prevent build summary failures due to self-hosted runner availability issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gounthar/unofficial-builds/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->