### PR TITLE
ci: run release check on github-hosted runner

### DIFF
--- a/.github/workflows/native-riscv64-build.yml
+++ b/.github/workflows/native-riscv64-build.yml
@@ -27,7 +27,11 @@ env:
 jobs:
   check-releases:
     name: Check for new Node.js releases
-    runs-on: [self-hosted, Linux, RISCV64]
+    # Only curls nodejs.org and lists GitHub releases, no RISC-V work. Keeping
+    # it on the self-hosted F3 runner adds a failure mode (runner-handoff miss)
+    # for no benefit and ties up the board for a metadata check. The build job
+    # below stays self-hosted and consumes this job's outputs unchanged.
+    runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.check.outputs.versions }}
       has_new: ${{ steps.check.outputs.has_new }}


### PR DESCRIPTION
Follow-up to #39.

`check-releases` only runs `curl https://nodejs.org/...`, `awk`/`grep`/`jq`, and `gh release list`. None of that needs riscv64. Keeping it on the self-hosted F3 runner means a metadata check ties up the board and shares the same runner-handoff failure mode that took down run [#219](https://github.com/gounthar/unofficial-builds/actions/runs/25982768851).

Moving it to `ubuntu-latest` leaves the F3 board touched only by the actual `build` job. `build` keeps `runs-on: [self-hosted, Linux, RISCV64]` and consumes `needs.check-releases.outputs.{versions,has_new}` unchanged — those are plain strings passed via `$GITHUB_OUTPUT`, runner-independent.

Independent of #39; either can merge first.